### PR TITLE
Cms updates

### DIFF
--- a/app/templates/not-found/template.html
+++ b/app/templates/not-found/template.html
@@ -1,0 +1,1 @@
+Not Found

--- a/config/json/db.json
+++ b/config/json/db.json
@@ -109,7 +109,13 @@
         "title": "Not Found",
         "content": ""
       },
-      "meta": {}
+      "meta": {
+        "title": "My AngularJS App - Not Found",
+        "tags": [
+          {"name": "description", "content": ""},
+          {"property": "og:locale", "content": "en_US"}
+        ]
+      }
     },
     {
       "id": 5,
@@ -118,19 +124,39 @@
         "title": "Home",
         "content": ""
       },
-      "meta": {}
+      "meta": {
+        "title": "My AngularJS App - Home",
+        "tags": [
+          {"name": "description", "content": ""},
+          {"property": "og:locale", "content": "en_US"}
+        ]
+      }
     },
     {
       "id": 10,
       "slug": "/sample-blog-post",
       "content": {},
-      "meta": {}
+      "meta": {
+        "title": "My AngularJS App - Sample Blog Post 1",
+        "tags": [
+          {"name": "description", "content": ""},
+          {"name": "twitter:card", "content": "summary"},
+          {"property": "og:locale", "content": "en_US"}
+        ]
+      }
     },
     {
       "id": 15,
       "slug": "/sample-blog-post-2",
       "content": {},
-      "meta": {}
+      "meta": {
+        "title": "My AngularJS App - Sample Blog Post 2",
+        "tags": [
+          {"name": "description", "content": ""},
+          {"name": "twitter:card", "content": "summary"},
+          {"property": "og:locale", "content": "en_US"}
+        ]
+      }
     }
   ],
   "collection": [

--- a/config/json/db.json
+++ b/config/json/db.json
@@ -1,6 +1,15 @@
 {
   "routes": [
     {
+      "url": "/not-found",
+      "state": "notFound",
+      "template": "not-found",
+      "endpoint": "post",
+      "params": {
+        "id": 1
+      }
+    },
+    {
       "url": "/",
       "state": "home",
       "template": "home",
@@ -10,8 +19,8 @@
       }
     },
     {
-      "state": "blogIndex",
       "url": "/blog",
+      "state": "blogIndex",
       "template": "blog",
       "endpoint": "collection",
       "params": {
@@ -19,13 +28,11 @@
       }
     },
     {
-      "state": "blogSingle",
       "url": "/blog/:slug",
+      "state": "blogSingle",
       "template": "blog-single",
       "endpoint": "post",
-      "params": {
-        "slug": ":slug"
-      }
+      "params": {}
     }
   ],
   "static": {
@@ -96,9 +103,17 @@
   },
   "post": [
     {
+      "id": 1,
+      "slug": "/not-found",
+      "content": {
+        "title": "Not Found",
+        "content": ""
+      },
+      "meta": {}
+    },
+    {
       "id": 5,
       "slug": "/",
-      "template": "home",
       "content": {
         "title": "Home",
         "content": ""
@@ -108,14 +123,12 @@
     {
       "id": 10,
       "slug": "/sample-blog-post",
-      "template": "blog-single",
       "content": {},
       "meta": {}
     },
     {
       "id": 15,
       "slug": "/sample-blog-post-2",
-      "template": "blog-single",
       "content": {},
       "meta": {}
     }

--- a/package.json
+++ b/package.json
@@ -24,7 +24,7 @@
     "gulp-uglify": "^1.5.3",
     "http-server": "^0.6.1",
     "json-server": "^0.8.8",
-    "ln-cms": "^0.3.1",
+    "ln-cms": "^0.4.4",
     "ln-filters": "^0.3.1",
     "node-sass": "^3.4.2",
     "npm-run-all": "^1.5.1",

--- a/public/index.html
+++ b/public/index.html
@@ -7,11 +7,9 @@
 <html lang="en" ng-app="app" ng-controller="LnCmsController as vm" class="no-js lt-ie9"> <![endif]-->
 <!--[if gt IE 8]><!-->
 <html lang="en" ng-app="app" ng-controller="LnCmsController as vm" class="no-js"> <!--<![endif]-->
-<head>
+<head ln-cms-meta="{{vm.view.meta}}">
 	<meta charset="utf-8">
 	<meta http-equiv="X-UA-Compatible" content="IE=edge">
-	<title>My AngularJS App</title>
-	<meta name="description" content="">
 	<meta name="viewport" content="width=device-width, initial-scale=1">
 
 	<!-- font inclusion -->


### PR DESCRIPTION
- **What kind of change does this PR introduce?** (Bug fix, feature,
  docs update, ...)

Update ln-cms verstion to 0.4.4.
Add Not Found template and route.
Add meta directive and example metadata for each view.
- **What is the current behavior?** (You can also link to an open issue
  here)

https://github.com/moxie-leean/ng-cms/issues/4
https://github.com/moxie-leean/ng-cms/issues/5
- **What is the new behavior (if this is a feature change)?**

When the user access a route that is not defined, the app links to the /not-found page.
You can now define custom meta tags for each view in the backend, which will be rendered on the head tag of the page.
- **Does this PR introduce a breaking change?** (What changes might
  users need to make in their application due to this PR?)

Customize the Not Found template.
Return custom meta on views data.
- **Other information**:
